### PR TITLE
Two additional examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.lein-failures
 /checkouts
 /.lein-deps-sum
+*~

--- a/src/analyze/examples/nsforms.clj
+++ b/src/analyze/examples/nsforms.clj
@@ -1,6 +1,5 @@
-(ns nsforms
-  (:require [analyze.core :as analyze])
-  (:require [clojure.pprint :as pp]))
+(ns analyze.examples.nsforms
+  (:require [analyze.core :as analyze]))
 
 (defn warn-on-naked-use [use-expr]
   (doseq [s (map :val (:args use-expr))

--- a/src/analyze/examples/nsforms.clj
+++ b/src/analyze/examples/nsforms.clj
@@ -1,0 +1,42 @@
+(ns nsforms
+  (:require [analyze.core :as analyze])
+  (:require [clojure.pprint :as pp]))
+
+(defn warn-on-naked-use [use-expr]
+  (doseq [s (map :val (:args use-expr))
+          :when (symbol? s)]
+    (println "Warning: Naked use of" (name s))))
+
+(defn use? [expr]
+  (and (= :invoke (:op expr))
+       (= :var (-> expr :fexpr :op))
+       (= 'use (-> expr :fexpr :var meta :name))))
+
+(defn find-and-analyze-use-forms [expr]
+  (when (use? expr)
+    (warn-on-naked-use expr))
+  (doseq [child-expr (:children expr)]
+    (find-and-analyze-use-forms child-expr)))
+
+(find-and-analyze-use-forms
+ (analyze/analyze-one {:ns {:name 'user} :context :eval}
+                      '(ns sjfis (:use [clojure.set :only [union]]
+                                       clojure.repl))))
+
+
+(def analyzed
+  (map #(apply analyze/analyze-path %) 
+       '[["clojure/test.clj" clojure.test]
+         ["clojure/set.clj" clojure.set]
+         ["clojure/java/io.clj" clojure.java.io]
+         ["clojure/stacktrace.clj" clojure.stacktrace]
+         ["clojure/pprint.clj" clojure.pprint]
+         ["clojure/walk.clj" clojure.walk]
+         ["clojure/string.clj" clojure.string]
+         ["clojure/repl.clj" clojure.repl]
+         ["clojure/core/protocols.clj" clojure.core.protocols]
+         ["clojure/template.clj" clojure.template]]))
+
+(doseq [exprs analyzed
+        exp exprs]
+  (find-and-analyze-use-forms exp))

--- a/src/analyze/examples/privatevars.clj
+++ b/src/analyze/examples/privatevars.clj
@@ -1,0 +1,45 @@
+(ns analyze.examples.privatevars
+  (:require [analyze.core :as analyze]
+            [clojure.set :as set]
+            [clojure.pprint :as pp]))
+
+(defn- unused-fn [] nil)
+(def ^:private unused-var 0)
+
+(defn defs [expr]
+  (apply concat
+         (when (= :def (:op expr)) [(:var expr)])
+         (map defs (:children expr))))
+
+(defn private-defs [expr]
+  (filter #(:private (meta %))
+          (defs expr)))
+
+(defn var-count [expr]
+  (if (= :var (:op expr))
+    {(:var expr) 1}
+    (apply merge-with +
+           (map var-count (:children expr)))))
+
+(defn check-usage-of-private-vars [exprs]
+  (let [v-count (apply merge-with + (map var-count exprs))]
+    (doseq [pvar (mapcat private-defs exprs)]
+      (when-not (get v-count pvar)
+        (println "Private variable" pvar "is never used")))))
+
+(def analyzed
+  (map #(apply analyze/analyze-path %) 
+       '[["clojure/test.clj" clojure.test]
+         ["clojure/set.clj" clojure.set]
+         ["clojure/java/io.clj" clojure.java.io]
+         ["clojure/stacktrace.clj" clojure.stacktrace]
+         ["clojure/pprint.clj" clojure.pprint]
+         ["clojure/walk.clj" clojure.walk]
+         ["clojure/string.clj" clojure.string]
+         ["clojure/repl.clj" clojure.repl]
+         ["clojure/core/protocols.clj" clojure.core.protocols]
+         ["clojure/template.clj" clojure.template]
+         ["analyze/examples/privatevars.clj" analyze.examples.privatevars]]))
+
+(doseq [exprs analyzed]
+  (check-usage-of-private-vars exprs))


### PR DESCRIPTION
Two more examples
1) warn on the use of (use 'some.namespace) instead of (use [some.namespace :only [x y z]])
2) warn when private variables are defined but never used.
