### PR TITLE
fixed `dissoc-rec` and a more general `print-expr`

### DIFF
--- a/src/analyze/util.clj
+++ b/src/analyze/util.clj
@@ -1,19 +1,18 @@
 (ns analyze.util
   (:require [clojure.pprint :as pp]))
 
-(defn- dissoc-rec
-  "dissoc[iate] keys recursively."
-  [m k]
-  (into {}
-        (for [[key val] (dissoc m k)]
-          [key (if (map? val)
-                 (dissoc-rec val k)
-                 val)])))
+(defn- dissoc-rec [obj & keys]
+  (cond
+   (map? obj) (into {} (for [[key val] (apply dissoc obj keys)]
+                         [key (apply dissoc-rec val keys)]))
+   (sequential? obj) (map #(apply dissoc-rec % keys) obj)
+   :else obj))
 
 (defn print-expr
-  "Pretty-prints expr, without :children keys"
-  [expr]
-  (pp/pprint (dissoc-rec expr :children)))
+  "Pretty-prints expr, excluding supplied keys.
+  Example: (print-expr expr :children :env)"
+  [expr & exclusions]
+  (pp/pprint (apply dissoc-rec expr exclusions)))
 
 (defn expr-seq
   "Given an expression, returns a lazy sequence of the expressions


### PR DESCRIPTION
The previous `dissoc-rec` was a bit broken as it didn't peek into sequences where lots of `:children` keys are. 

I also made `print-expr` more general. It's now possible to supply keys to exclude. For example, I often don't want to be distracted by `:env` and `:Expr-obj` keys when analyzing the output of `analyze-one`.

However, I'm not totally sold on the interface. What do you think is better: 

```
(print-expr expr :children :env :Expr-obj)
```

or 

```
(print-expr expr :exclude [:children :env :Expr-obj])
```

The latter would open up for an `:only` option, i.e., 

```
(print-expr expr :only [:op :env])
```

Btw, when is it time for a new release to clojars. Do you want to be able to analyze `clojure.core` before a new release?
